### PR TITLE
Add delay to send message to forum

### DIFF
--- a/src/DiscordApp.ts
+++ b/src/DiscordApp.ts
@@ -9,7 +9,7 @@ export class DiscordApp {
 
   constructor() {
     DiscordApp.client.on("ready", () => this.clientIsReady());
-    DiscordApp.client.on("messageCreate", (message: Message) => void this.handleMessages(message));
+    DiscordApp.client.on("messageCreate", (message: Message) => this.handleMessages(message));
   }
 
   public async start(): Promise<void> {
@@ -39,8 +39,8 @@ export class DiscordApp {
     });
   }
 
-  private async handleMessages(message: Message) {
-    await new MessageHandler(message).handle();
+  private handleMessages(message: Message) {
+    new MessageHandler(message).handle();
   }
 }
 

--- a/src/handler/MessageHandler.ts
+++ b/src/handler/MessageHandler.ts
@@ -9,7 +9,7 @@ export class MessageHandler {
     this.message = message;
   }
 
-  public async handle(): Promise<void> {
+  public handle(): void {
     if (
       !(this.message.channel instanceof ThreadChannel) ||
       this.message.guildId != config.discord.guildID ||
@@ -18,6 +18,10 @@ export class MessageHandler {
       return;
     }
 
+    setTimeout(() => void this.sendResponse(), 5 * 1000);
+  }
+
+  public async sendResponse(): Promise<void> {
     const payload = {
       discordThreadID: this.message.channelId,
       discordMessageID: this.message.id,


### PR DESCRIPTION
Currently messages are sent directly. As a result, messages are sometimes pushed from the forum to Discord and then written directly back to the forum. Therefore messages in the forum are sometimes duplicated. A small delay fixes this problem.